### PR TITLE
Refactored APOD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Go Tests
-        run: go test -v -tags=integration
-        run: go test -cover
+        run: |
+          go test -v -tags=integration
+          go test -cover

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,4 @@ jobs:
 
       - name: Go Tests
         run: go test -v -tags=integration
+        run: go test -cover

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 test.sh
+*.out

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ func main() {
 ### APOD
 ---
 
+Note: All responses will return an array of ApodResults. Including Apod() which will return an array of size 1.
+
 Grabbing the APOD for today
 
 ```go
@@ -76,7 +78,7 @@ func main() {
 
     result, err := client.Apod()
 
-    fmt.Println(*result)
+    fmt.Println(result[0])
 }
 ```
 
@@ -91,6 +93,7 @@ func main() {
     }
 
     res, err := nasa.ApodWOpt(options)
+    fmt.Println(res[0])
 }
 ```
 
@@ -110,7 +113,7 @@ ApodCount(int)
 ApodCountWThumbs(int)
 ```
 
-Output
+Output is an array of:
 ```go
 type ApodResults struct {
     // an optional return parameter copyright is returned if the image is not public domain

--- a/apod.go
+++ b/apod.go
@@ -55,19 +55,22 @@ func (a *ApodOptions) params() url.Values {
 }
 
 /* Returns Apod for today*/
-func (c *Client) Apod() (*ApodResults, error) {
+func (c *Client) Apod() ([]ApodResults, error) {
 	return c.ApodWOpt(nil)
 }
 
-func (c *Client) ApodWOpt(options *ApodOptions) (*ApodResults, error) {
+func (c *Client) ApodWOpt(options *ApodOptions) ([]ApodResults, error) {
 	var data ApodResults
 
+	// set it as ApodResults then only set array if its startdate - end date
+	// then for regular date create of size 0
 	if options == nil {
 		err := c.getJSON(apodAPI, options, &data)
 		if err != nil {
 			return nil, err
 		}
-		return &data, nil
+		d := []ApodResults{data}
+		return d, nil
 	}
 	if options.Date != "" && (options.StartDate != "" || options.EndDate != "") {
 		return nil, errors.New("date options cannot be used with StartDate and EndDate")
@@ -80,7 +83,8 @@ func (c *Client) ApodWOpt(options *ApodOptions) (*ApodResults, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &data, nil
+		d := []ApodResults{data}
+		return d, nil
 	}
 	if (options.StartDate == "" && options.EndDate != "") || (options.StartDate != "" && options.EndDate == "") {
 		return nil, errors.New("StartDate/EndDate option missing EndDate/StartDate option")
@@ -91,12 +95,13 @@ func (c *Client) ApodWOpt(options *ApodOptions) (*ApodResults, error) {
 	if _, err := time.Parse(layoutISO, options.EndDate); err != nil {
 		return nil, errors.New("incorrect EndDate format")
 	}
-	err := c.getJSON(apodAPI, options, &data)
+	var arr []ApodResults
+	err := c.getJSON(apodAPI, options, &arr)
 
 	if err != nil {
 		return nil, err
 	}
-	return &data, nil
+	return arr, nil
 }
 
 type countOptions struct {
@@ -114,7 +119,7 @@ func (c *countOptions) params() url.Values {
 }
 
 /* Randomly chosen images will be returned. Cannot be used with date or start_date and end_date */
-func (c *Client) ApodCount(count int) (*[]ApodResults, error) {
+func (c *Client) ApodCount(count int) ([]ApodResults, error) {
 	return c.countHelper(count, false)
 }
 
@@ -122,10 +127,10 @@ func (c *Client) ApodCount(count int) (*[]ApodResults, error) {
 	Randomly chosen images will be returned with thumbnails. Cannot be used with date or start_date and end_date.
 	If an APOD is not a video, this parameter is ignored.
 */
-func (c *Client) ApodCountWThumbs(count int) (*[]ApodResults, error) {
+func (c *Client) ApodCountWThumbs(count int) ([]ApodResults, error) {
 	return c.countHelper(count, true)
 }
-func (c *Client) countHelper(count int, thumbs bool) (*[]ApodResults, error) {
+func (c *Client) countHelper(count int, thumbs bool) ([]ApodResults, error) {
 	var arr []ApodResults
 	options := &countOptions{
 		count:  count,
@@ -135,5 +140,5 @@ func (c *Client) countHelper(count int, thumbs bool) (*[]ApodResults, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &arr, nil
+	return arr, nil
 }

--- a/apod.go
+++ b/apod.go
@@ -1,15 +1,20 @@
 package nasa
 
 import (
+	"errors"
 	"fmt"
-	"net/http"
+	"net/url"
 	"time"
 )
 
 const (
-	apodEndpoint = "https://api.nasa.gov/planetary/apod"
-	layoutISO    = "2006-01-02"
+	layoutISO = "2006-01-02"
 )
+
+var apodAPI = &apiConfig{
+	host: "https://api.nasa.gov",
+	path: "/planetary/apod",
+}
 
 type ApodResults struct {
 	Copyright      string `json:"copyright"`
@@ -29,69 +34,83 @@ type ApodOptions struct {
 	Thumbs    bool
 }
 
+func (a *ApodOptions) params() url.Values {
+	q := make(url.Values)
+	if a == nil {
+		return q
+	}
+	if a.Date != "" {
+		q.Set("date", a.Date)
+	}
+	if a.StartDate != "" {
+		q.Set("start_date", a.StartDate)
+	}
+	if a.EndDate != "" {
+		q.Set("end_date", a.EndDate)
+	}
+	if a.Thumbs {
+		q.Set("thumbs", "true")
+	}
+	return q
+}
+
 /* Returns Apod for today*/
 func (c *Client) Apod() (*ApodResults, error) {
 	return c.ApodWOpt(nil)
 }
 
-/* Returns Apod based on options */
-func (c *Client) ApodWOpt(o *ApodOptions) (*ApodResults, error) {
-	req, err := http.NewRequest("GET", apodEndpoint, nil)
-
-	if err != nil {
-		return nil, err
-	}
-
+func (c *Client) ApodWOpt(options *ApodOptions) (*ApodResults, error) {
 	var data ApodResults
-	if o == nil {
-		err = c.send(req, &data)
+
+	if options == nil {
+		err := c.getJSON(apodAPI, options, &data)
 		if err != nil {
 			return nil, err
 		}
 		return &data, nil
 	}
-
-	if o.Date != "" && (o.StartDate != "" || o.EndDate != "") {
-		return nil, fmt.Errorf("date option cannot be used with StartDate or EndDate")
+	if options.Date != "" && (options.StartDate != "" || options.EndDate != "") {
+		return nil, errors.New("date options cannot be used with StartDate and EndDate")
 	}
-	q := req.URL.Query()
-
-	if o.Thumbs {
-		q.Add("thumbs", "true")
-	}
-
-	if o.Date != "" {
-		p, err := time.Parse(layoutISO, o.Date)
-		if err != nil {
+	if options.Date != "" {
+		if _, err := time.Parse(layoutISO, options.Date); err != nil {
 			return nil, err
 		}
-		q.Add("date", p.Format(layoutISO))
-		req.URL.RawQuery = q.Encode()
-		err = c.send(req, &data)
+		err := c.getJSON(apodAPI, options, &data)
 		if err != nil {
 			return nil, err
 		}
 		return &data, nil
 	}
-	if (o.StartDate == "" && o.EndDate != "") || (o.StartDate != "" && o.EndDate == "") {
-		return nil, fmt.Errorf("missing option StartDate or EndDate")
+	if (options.StartDate == "" && options.EndDate != "") || (options.StartDate != "" && options.EndDate == "") {
+		return nil, errors.New("StartDate/EndDate option missing EndDate/StartDate option")
 	}
+	if _, err := time.Parse(layoutISO, options.StartDate); err != nil {
+		return nil, errors.New("incorrect StartDate format")
+	}
+	if _, err := time.Parse(layoutISO, options.EndDate); err != nil {
+		return nil, errors.New("incorrect EndDate format")
+	}
+	err := c.getJSON(apodAPI, options, &data)
 
-	if _, err := time.Parse(layoutISO, o.StartDate); err != nil {
-		return nil, err
-	}
-	if _, err := time.Parse(layoutISO, o.EndDate); err != nil {
-		return nil, err
-	}
-	q.Add("start_date", o.StartDate)
-	q.Add("end_date", o.EndDate)
-
-	req.URL.RawQuery = q.Encode()
-	err = c.send(req, &data)
 	if err != nil {
 		return nil, err
 	}
 	return &data, nil
+}
+
+type countOptions struct {
+	count  int
+	thumbs bool
+}
+
+func (c *countOptions) params() url.Values {
+	q := make(url.Values)
+	q.Set("count", fmt.Sprint(c.count))
+	if c.thumbs {
+		q.Set("thumbs", "true")
+	}
+	return q
 }
 
 /* Randomly chosen images will be returned. Cannot be used with date or start_date and end_date */
@@ -108,14 +127,11 @@ func (c *Client) ApodCountWThumbs(count int) (*[]ApodResults, error) {
 }
 func (c *Client) countHelper(count int, thumbs bool) (*[]ApodResults, error) {
 	var arr []ApodResults
-	req, _ := http.NewRequest("GET", apodEndpoint, nil)
-	q := req.URL.Query()
-	if thumbs {
-		q.Add("thumbs", "true")
+	options := &countOptions{
+		count:  count,
+		thumbs: thumbs,
 	}
-	q.Add("count", fmt.Sprint(count))
-	req.URL.RawQuery = q.Encode()
-	err := c.send(req, &arr)
+	err := c.getJSON(apodAPI, options, &arr)
 	if err != nil {
 		return nil, err
 	}

--- a/apod_test.go
+++ b/apod_test.go
@@ -1,31 +1,79 @@
 package nasa
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
 	"testing"
-	"time"
 )
 
+func mockServer(code int, body string) *httptest.Server {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(code)
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		fmt.Fprintln(w, body)
+	}))
+	return s
+}
+
 func TestApod(t *testing.T) {
-	client := NewClient()
 
-	d := time.Now().Format(layoutISO)
+	mockData := `{
+		"copyright": "Damian Peach",
+		"date": "2021-09-19",
+		"explanation": "On Saturn, the rings tell you the season. On Earth, Wednesday marks an equinox, the time when the  Earth's equator tilts directly toward the Sun. Since Saturn's grand rings orbit along the planet's equator, these rings appear most prominent -- from the direction of the Sun -- when the spin axis of Saturn points toward the Sun. Conversely, when Saturn's spin axis points to the side, an equinox occurs and the edge-on rings are hard to see from not only the Sun -- but Earth. In the featured montage, images of Saturn between the years of 2004 and 2015 have been superposed to show the giant planet passing from southern summer toward northern summer. Saturn was as close as it can get to planet Earth last month, and this month the ringed giant is still bright and visible throughout much of the night",
+		"hdurl": "https://apod.nasa.gov/apod/image/2109/saturn2004to2015_peach_2504.jpg",
+		"media_type": "image",
+		"service_version": "v1",
+		"title": "Rings and Seasons of Saturn",
+		"url": "https://apod.nasa.gov/apod/image/2109/saturn2004to2015_peach_960.jpg"
+		}`
+	server := mockServer(200, mockData)
+	defer server.Close()
 
-	o := &ApodOptions{
-		Date: d,
-	}
-	res, err := client.ApodWOpt(o)
+	client := NewClient(WithBaseURL(server.URL))
+
+	resp, err := client.Apod()
 
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	if res.Date != d {
-		t.Errorf("date not matching %v %v", res.Date, d)
+
+	if resp[0].Date != "2021-09-19" {
+		t.Errorf("date not matching %v %v", resp[0].Date, "2021-09-19")
+	}
+	correctResponse := &ApodResults{
+		Copyright:      "Damian Peach",
+		Date:           "2021-09-19",
+		Explanation:    "On Saturn, the rings tell you the season. On Earth, Wednesday marks an equinox, the time when the  Earth's equator tilts directly toward the Sun. Since Saturn's grand rings orbit along the planet's equator, these rings appear most prominent -- from the direction of the Sun -- when the spin axis of Saturn points toward the Sun. Conversely, when Saturn's spin axis points to the side, an equinox occurs and the edge-on rings are hard to see from not only the Sun -- but Earth. In the featured montage, images of Saturn between the years of 2004 and 2015 have been superposed to show the giant planet passing from southern summer toward northern summer. Saturn was as close as it can get to planet Earth last month, and this month the ringed giant is still bright and visible throughout much of the night",
+		Hdurl:          "https://apod.nasa.gov/apod/image/2109/saturn2004to2015_peach_2504.jpg",
+		MediaType:      "image",
+		ServiceVersion: "v1",
+		Title:          "Rings and Seasons of Saturn",
+		URL:            "https://apod.nasa.gov/apod/image/2109/saturn2004to2015_peach_960.jpg",
+	}
+	if !reflect.DeepEqual(*correctResponse, resp[0]) {
+		t.Errorf("incorrect response expected: %+v, was \n%+v", *correctResponse, resp[0])
 	}
 }
 
 func TestApodWDate(t *testing.T) {
-	client := NewClient()
+	mockData := `{
+		"date": "2021-09-14",
+		"explanation": "Which way up Mount Sharp? In early September, the robotic rover Curiosity continued its ascent up the central peak of Gale Crater, searching for more clues about ancient water and further evidence that Mars could once have been capable of supporting life.  On this recent Martian morning, before exploratory drilling, the rolling rover took this 360-degree panorama, in part to help Curiosity's human team back on Earth access the landscape and chart possible future routes.  In the horizontally-compressed featured image, an amazing vista across Mars was captured, complete with layered hills, red rocky ground, gray drifting sand, and a dusty atmosphere. The hill just left of center has been dubbed Maria Gordon Notch in honor of a famous Scottish geologist.  The current plan is to direct Curiosity to approach, study, and pass just to the right of Gordon Notch on its exploratory trek.",
+		"hdurl": "https://apod.nasa.gov/apod/image/2109/MarsPan360_Curiosity_6144.jpg",
+		"media_type": "image",
+		"service_version": "v1",
+		"title": "Mars Panorama 360 from Curiosity",
+		"url": "https://apod.nasa.gov/apod/image/2109/MarsPanCompressed_Curiosity_1080.jpg"
+		}
+	`
+
+	server := mockServer(200, mockData)
+	defer server.Close()
+	client := NewClient(WithBaseURL(server.URL))
 
 	params := &ApodOptions{
 		Date: "2021-09-14",
@@ -37,13 +85,46 @@ func TestApodWDate(t *testing.T) {
 		return
 	}
 
-	if res.Date != "2021-09-14" {
+	if res[0].Date != "2021-09-14" {
 		t.Errorf("incorrect date")
+	}
+	correctResponse := &ApodResults{
+		Date:           "2021-09-14",
+		Explanation:    "Which way up Mount Sharp? In early September, the robotic rover Curiosity continued its ascent up the central peak of Gale Crater, searching for more clues about ancient water and further evidence that Mars could once have been capable of supporting life.  On this recent Martian morning, before exploratory drilling, the rolling rover took this 360-degree panorama, in part to help Curiosity's human team back on Earth access the landscape and chart possible future routes.  In the horizontally-compressed featured image, an amazing vista across Mars was captured, complete with layered hills, red rocky ground, gray drifting sand, and a dusty atmosphere. The hill just left of center has been dubbed Maria Gordon Notch in honor of a famous Scottish geologist.  The current plan is to direct Curiosity to approach, study, and pass just to the right of Gordon Notch on its exploratory trek.",
+		Hdurl:          "https://apod.nasa.gov/apod/image/2109/MarsPan360_Curiosity_6144.jpg",
+		MediaType:      "image",
+		ServiceVersion: "v1",
+		Title:          "Mars Panorama 360 from Curiosity",
+		URL:            "https://apod.nasa.gov/apod/image/2109/MarsPanCompressed_Curiosity_1080.jpg",
+	}
+	if !reflect.DeepEqual(*correctResponse, res[0]) {
+		t.Errorf("incorrect response expected: %+v\nreceived: %+v", *correctResponse, res[0])
 	}
 }
 
 func TestApodCount(t *testing.T) {
-	client := NewClient()
+	mockData := `[{
+		"copyright": "Damian Peach",
+		"date": "2021-09-19",
+		"explanation": "On Saturn, the rings tell you the season. On Earth, Wednesday marks an equinox, the time when the  Earth's equator tilts directly toward the Sun. Since Saturn's grand rings orbit along the planet's equator, these rings appear most prominent -- from the direction of the Sun -- when the spin axis of Saturn points toward the Sun. Conversely, when Saturn's spin axis points to the side, an equinox occurs and the edge-on rings are hard to see from not only the Sun -- but Earth. In the featured montage, images of Saturn between the years of 2004 and 2015 have been superposed to show the giant planet passing from southern summer toward northern summer. Saturn was as close as it can get to planet Earth last month, and this month the ringed giant is still bright and visible throughout much of the night",
+		"hdurl": "https://apod.nasa.gov/apod/image/2109/saturn2004to2015_peach_2504.jpg",
+		"media_type": "image",
+		"service_version": "v1",
+		"title": "Rings and Seasons of Saturn",
+		"url": "https://apod.nasa.gov/apod/image/2109/saturn2004to2015_peach_960.jpg"
+		},{
+			"date": "2021-09-14",
+			"explanation": "Which way up Mount Sharp? In early September, the robotic rover Curiosity continued its ascent up the central peak of Gale Crater, searching for more clues about ancient water and further evidence that Mars could once have been capable of supporting life.  On this recent Martian morning, before exploratory drilling, the rolling rover took this 360-degree panorama, in part to help Curiosity's human team back on Earth access the landscape and chart possible future routes.  In the horizontally-compressed featured image, an amazing vista across Mars was captured, complete with layered hills, red rocky ground, gray drifting sand, and a dusty atmosphere. The hill just left of center has been dubbed Maria Gordon Notch in honor of a famous Scottish geologist.  The current plan is to direct Curiosity to approach, study, and pass just to the right of Gordon Notch on its exploratory trek.",
+			"hdurl": "https://apod.nasa.gov/apod/image/2109/MarsPan360_Curiosity_6144.jpg",
+			"media_type": "image",
+			"service_version": "v1",
+			"title": "Mars Panorama 360 from Curiosity",
+			"url": "https://apod.nasa.gov/apod/image/2109/MarsPanCompressed_Curiosity_1080.jpg"
+		}]
+	`
+	server := mockServer(200, mockData)
+	defer server.Close()
+	client := NewClient(WithBaseURL(server.URL))
 
 	res, err := client.ApodCount(2)
 
@@ -52,15 +133,35 @@ func TestApodCount(t *testing.T) {
 		return
 	}
 
-	if len(*res) != 2 {
+	if len(res) != 2 {
 		t.Errorf("returns incorrect number of elements")
+		return
 	}
-}
-func TestRateLimit(t *testing.T) {
-	client := NewClient()
+	correctResponse := []ApodResults{
+		{
+			Copyright:      "Damian Peach",
+			Date:           "2021-09-19",
+			Explanation:    "On Saturn, the rings tell you the season. On Earth, Wednesday marks an equinox, the time when the  Earth's equator tilts directly toward the Sun. Since Saturn's grand rings orbit along the planet's equator, these rings appear most prominent -- from the direction of the Sun -- when the spin axis of Saturn points toward the Sun. Conversely, when Saturn's spin axis points to the side, an equinox occurs and the edge-on rings are hard to see from not only the Sun -- but Earth. In the featured montage, images of Saturn between the years of 2004 and 2015 have been superposed to show the giant planet passing from southern summer toward northern summer. Saturn was as close as it can get to planet Earth last month, and this month the ringed giant is still bright and visible throughout much of the night",
+			Hdurl:          "https://apod.nasa.gov/apod/image/2109/saturn2004to2015_peach_2504.jpg",
+			MediaType:      "image",
+			ServiceVersion: "v1",
+			Title:          "Rings and Seasons of Saturn",
+			URL:            "https://apod.nasa.gov/apod/image/2109/saturn2004to2015_peach_960.jpg",
+		},
+		{
+			Date:           "2021-09-14",
+			Explanation:    "Which way up Mount Sharp? In early September, the robotic rover Curiosity continued its ascent up the central peak of Gale Crater, searching for more clues about ancient water and further evidence that Mars could once have been capable of supporting life.  On this recent Martian morning, before exploratory drilling, the rolling rover took this 360-degree panorama, in part to help Curiosity's human team back on Earth access the landscape and chart possible future routes.  In the horizontally-compressed featured image, an amazing vista across Mars was captured, complete with layered hills, red rocky ground, gray drifting sand, and a dusty atmosphere. The hill just left of center has been dubbed Maria Gordon Notch in honor of a famous Scottish geologist.  The current plan is to direct Curiosity to approach, study, and pass just to the right of Gordon Notch on its exploratory trek.",
+			Hdurl:          "https://apod.nasa.gov/apod/image/2109/MarsPan360_Curiosity_6144.jpg",
+			MediaType:      "image",
+			ServiceVersion: "v1",
+			Title:          "Mars Panorama 360 from Curiosity",
+			URL:            "https://apod.nasa.gov/apod/image/2109/MarsPanCompressed_Curiosity_1080.jpg",
+		},
+	}
 
-	client.ApodCount(1)
-
+	if !reflect.DeepEqual(correctResponse, res) {
+		t.Errorf("incorrect response expected: %+v\nreceived: %+v\n", correctResponse, res)
+	}
 }
 
 func TestInvalidDate(t *testing.T) {
@@ -76,5 +177,189 @@ func TestInvalidDate(t *testing.T) {
 
 	if err == nil {
 		t.Errorf("invalid date not checked")
+	}
+}
+
+func TestInvalidOptions(t *testing.T) {
+	client := NewClient()
+
+	date := "2021-09-10"
+	startDate := "2021-05-1"
+	endDate := "2021-06-1"
+
+	options := &ApodOptions{
+		Date:      date,
+		StartDate: startDate,
+		EndDate:   endDate,
+	}
+	_, err := client.ApodWOpt(options)
+	if err == nil {
+		t.Errorf("expected error received nil")
+	}
+}
+
+func TestDateRange(t *testing.T) {
+	mockData := `[
+		{
+		"copyright": "T. Humbert, S. Barré, A. Desmougin & D. WalliangSociété Lorraine d'AstronomieAstroqueyras",
+		"date": "2021-09-17",
+		"explanation": "There has been a flash on Jupiter. A few days ago, several groups monitoring our Solar System's largest planet noticed a two-second long burst of light. Such flashes have been seen before, with the most famous being a series of impactor strikes in 1994. Then, fragments of Comet Shoemaker-Levy 9 struck  Jupiter leaving dark patches that lasted for months. Since then, at least seven impacts have been recorded on Jupiter -- usually discovered by amateur astronomers. In the featured video, variations in the Earth's atmosphere cause Jupiter's image to shimmer when, suddenly, a bright flash appears just left of center.  Io and its shadow are visible on the right. What hit Jupiter will likely never be known, but considering what we do know of the nearby Solar System, it was likely a piece of rock and ice -- perhaps the size of a bus -- that broke off long-ago from a passing comet or asteroid.",
+		"media_type": "video",
+		"service_version": "v1",
+		"title": "Video: Flash on Jupiter",
+		"url": "https://www.youtube.com/embed/ImVl_TfTFEY?rel=0"
+		},
+		{
+		"date": "2021-09-18",
+		"explanation": "In this Hubble Space Telescope image the bright, spiky stars lie in the foreground toward the heroic northern constellation Perseus and well within our own Milky Way galaxy. In sharp focus beyond is UGC 2885, a giant spiral galaxy about 232 million light-years distant. Some 800,000 light-years across compared to the Milky Way's diameter of 100,000 light-years or so, it has around 1 trillion stars. That's about 10 times as many stars as the Milky Way. Part of an investigation to understand how galaxies can grow to such enormous sizes, UGC 2885 was also part of An Interesting Voyage and astronomer Vera Rubin's pioneering study of the rotation of spiral galaxies. Her work was the first to convincingly demonstrate the dominating presence of dark matter in our universe.",
+		"hdurl": "https://apod.nasa.gov/apod/image/2109/RubinsGalaxy_hst2000.jpg",
+		"media_type": "image",
+		"service_version": "v1",
+		"title": "Rubin's Galaxy",
+		"url": "https://apod.nasa.gov/apod/image/2109/RubinsGalaxy_hst1024.jpg"
+		},
+		{
+		"copyright": "Damian Peach",
+		"date": "2021-09-19",
+		"explanation": "On Saturn, the rings tell you the season. On Earth, Wednesday marks an equinox, the time when the  Earth's equator tilts directly toward the Sun. Since Saturn's grand rings orbit along the planet's equator, these rings appear most prominent -- from the direction of the Sun -- when the spin axis of Saturn points toward the Sun. Conversely, when Saturn's spin axis points to the side, an equinox occurs and the edge-on rings are hard to see from not only the Sun -- but Earth. In the featured montage, images of Saturn between the years of 2004 and 2015 have been superposed to show the giant planet passing from southern summer toward northern summer. Saturn was as close as it can get to planet Earth last month, and this month the ringed giant is still bright and visible throughout much of the night",
+		"hdurl": "https://apod.nasa.gov/apod/image/2109/saturn2004to2015_peach_2504.jpg",
+		"media_type": "image",
+		"service_version": "v1",
+		"title": "Rings and Seasons of Saturn",
+		"url": "https://apod.nasa.gov/apod/image/2109/saturn2004to2015_peach_960.jpg"
+		}
+		]`
+	server := mockServer(200, mockData)
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+	options := &ApodOptions{
+		StartDate: "2021-09-17",
+		EndDate:   "2021-09-19",
+	}
+
+	resp, err := client.ApodWOpt(options)
+
+	if err != nil {
+		t.Errorf("expected no error received %s", err)
+	}
+	if len(resp) != 3 {
+		t.Errorf("expected an array of size 3, received %d", len(resp))
+	}
+}
+
+func TestRequestError(t *testing.T) {
+	client := NewClient(WithBaseURL("dsadas"))
+
+	_, err := client.Apod()
+
+	if err == nil {
+		t.Errorf("expected error received nil")
+	}
+}
+
+func TestApodOptionError(t *testing.T) {
+	client := NewClient(WithBaseURL("dsadsa"))
+
+	options := &ApodOptions{
+		Date:   "2020-12-01",
+		Thumbs: true,
+	}
+	_, err := client.ApodWOpt(options)
+
+	if err == nil {
+		t.Errorf("expected error received nil")
+	}
+}
+
+func TestMissingEndDate(t *testing.T) {
+	client := NewClient()
+
+	options := &ApodOptions{
+		StartDate: "2021-09-01",
+	}
+	_, err := client.ApodWOpt(options)
+	if err == nil {
+		t.Errorf("expected error received nil")
+	}
+}
+func TestMissingStartDate(t *testing.T) {
+	client := NewClient()
+
+	options := &ApodOptions{
+		EndDate: "2021-09-01",
+	}
+	_, err := client.ApodWOpt(options)
+	if err == nil {
+		t.Errorf("expected error received nil")
+	}
+}
+
+func TestIncorrectStartFormat(t *testing.T) {
+	client := NewClient()
+
+	options := &ApodOptions{
+		StartDate: "Jan. 26, 2021",
+		EndDate:   "2021-09-01",
+	}
+	_, err := client.ApodWOpt(options)
+	if err == nil {
+		t.Errorf("expected error received nil")
+	}
+}
+func TestIncorrectEndFormat(t *testing.T) {
+	client := NewClient()
+
+	options := &ApodOptions{
+		EndDate:   "Jan. 26, 2021",
+		StartDate: "2021-09-01",
+	}
+	_, err := client.ApodWOpt(options)
+	if err == nil {
+		t.Errorf("expected error received nil")
+	}
+}
+
+func TestBadBaseURL(t *testing.T) {
+	client := NewClient(WithBaseURL("random"))
+
+	options := &ApodOptions{
+		EndDate:   "2021-08-01",
+		StartDate: "2021-09-01",
+	}
+	_, err := client.ApodWOpt(options)
+	if err == nil {
+		t.Errorf("expected error received nil")
+	}
+}
+
+func TestCountWThumbsError(t *testing.T) {
+	client := NewClient(WithBaseURL("random"))
+
+	_, err := client.ApodCountWThumbs(2)
+
+	if err == nil {
+		t.Errorf("expected error received nil")
+	}
+}
+
+func TestNewRequestError(t *testing.T) {
+	client := NewClient(WithBaseURL("%"))
+
+	_, err := client.ApodCountWThumbs(2)
+
+	if err == nil {
+		t.Errorf("expected error received nil")
+	}
+}
+
+func TestRandomServerError(t *testing.T) {
+	server := mockServer(500, "Internal Server Error")
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+	_, err := client.Apod()
+	if err == nil {
+		t.Errorf("expected error received nil")
 	}
 }

--- a/apod_test.go
+++ b/apod_test.go
@@ -59,7 +59,7 @@ func TestApodCount(t *testing.T) {
 func TestRateLimit(t *testing.T) {
 	client := NewClient()
 
-	client.ApodCount(10)
+	client.ApodCount(1)
 
 }
 

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package nasa
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -46,7 +47,7 @@ func WithClient(h *http.Client) ClientOption {
 	}
 }
 
-func WithBase(url string) ClientOption {
+func WithBaseURL(url string) ClientOption {
 	return func(c *Client) {
 		c.baseURL = url
 	}
@@ -62,23 +63,6 @@ func (c *Client) Key() string {
 func (c *Client) HttpClient() *http.Client {
 	return c.httpClient
 }
-
-// func (c *Client) send(req *http.Request, d interface{}) error {
-// 	q := req.URL.Query()
-// 	q.Add("api_key", c.apiKey)
-// 	req.URL.RawQuery = q.Encode()
-
-// 	res, err := c.httpClient.Do(req)
-// 	if err != nil {
-// 		return err
-// 	}
-
-// 	if res.StatusCode != http.StatusOK {
-// 		return fmt.Errorf(res.Status)
-// 	}
-// 	fmt.Sscan(res.Header.Get("X-RateLimit-Remaining"), &c.rateLimit)
-// 	return json.NewDecoder(res.Body).Decode(d)
-// }
 
 type apiConfig struct {
 	host string
@@ -117,7 +101,7 @@ func (c *Client) getJSON(config *apiConfig, apiReq apiRequest, d interface{}) er
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf(res.Status)
+		return errors.New(res.Status)
 	}
 	fmt.Sscan(res.Header.Get("X-RateLimit-Remaining"), &c.rateLimit)
 	return json.NewDecoder(res.Body).Decode(d)

--- a/client_test.go
+++ b/client_test.go
@@ -36,3 +36,17 @@ func TestSetHTTPClient(t *testing.T) {
 		t.Errorf("http client not set")
 	}
 }
+
+func TestGetters(t *testing.T) {
+	client := NewClient(WithKey("random"))
+
+	if client.Key() != "random" {
+		t.Errorf("incorrect client api key set")
+	}
+	if client.HttpClient() != http.DefaultClient {
+		t.Errorf("incorrect http client set")
+	}
+	if client.RateLimit() != 0 {
+		t.Errorf("incorrect rate limit set")
+	}
+}


### PR DESCRIPTION
## Implementations

- Changed endpoints are requested, such that each new endpoint being added from now on has to follow an interface layout.
- Added BaseURL which helps with mock tests and if someone would want to use a local server
- Implemented mock server for tests
- All APOD functions returns an array, helps with keeping the same layout across functions. And decreases complexity with dealing with start/end date and date options.
- Code coverage 100%
- apiRequest interface 
- apiConfig struct